### PR TITLE
Make the local build truly local

### DIFF
--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -20,8 +20,10 @@
     (url-insert-file-contents "https://raw.github.com/quelpa/quelpa/master/bootstrap.el")
     (eval-buffer)))
 
-;;; (quelpa '(frontmacs :fetcher url :url "file:///Users/robertdeluca/Projects/frontmacs/frontmacs.el" ))
-(quelpa '(frontmacs :fetcher github :repo "thefrontside/frontmacs" ))
+(if (getenv "FRONTMACS_RUNLOCAL")
+    (quelpa '(frontmacs :fetcher file :path "~/../lib" ))
+  (quelpa '(frontmacs :fetcher github :repo "thefrontside/frontmacs" )))
+
 
 (require 'frontmacs)
 ;;; init.el ends here

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-.emacs.d/quelpa
-.emacs.d/elpa
-.emacs.d/personal
-.emacs.d/auto-save-list
-.gnupg
 *~
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+build:
+	mkdir -p build/home
+	mkdir -p build/lib
+	cp -r .emacs.d build/home
+	cp *.el build/lib
 clean:
-	rm -rf .emacs.d/elpa
-	rm -rf .emacs.d/smex-items
-	rm -rf .emacs.d/quelpa
+	rm -rf build
 
-runlocal: clean
-	HOME=`pwd` emacs -nw
+runlocal: build
+	FRONTMACS_RUNLOCAL=true HOME=`pwd`/build/home emacs -nw


### PR DESCRIPTION
We kept running into problems with using the root of the source
directory as the home directory for the simulated build. Emacs kept
putting turds all over the root directory in the form of `save-list`,
`elpa`, `quelpa`, etc... Addittionally, there was no way to use the
quelpa fetcher to set the package source directory as the repo root
directory. It just wouldn't do it.

The answer then, is to just make a `/build` directory that can house
all of the sources and all of the temp files, and can be swept away
simply. So now, the only thing that is ignored is `build`

```
build/home -> contains the simulated home directory
build/lib -> all of the frontmacs elisp sources
```

If the `FRONTMACS_RUNLOCAL` variable is defined, then the provided
`init.el` will try and use the soures from the file system, otherwise
it will use the latest on github.