### PR TITLE
Add configuration and initialization mechanism

### DIFF
--- a/Cask
+++ b/Cask
@@ -7,4 +7,5 @@
  (depends-on "f")
  (depends-on "ecukes")
  (depends-on "ert-runner")
- (depends-on "el-mock"))
+ (depends-on "el-mock")
+ (depends-on "dash"))

--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ add the following lines to the top of your `init.el`:
 
 Restart your Emacs and away you go!
 
+## Configuration
+
+Frontmacs will create several files and directories in your Emacs
+directory (usually `$HOME/.emacs.d`) to help with configuration and
+initialization. The first is `config.el` This file is loaded _before_
+Frontmacs actually initializes, and so it's a chance to set any
+well defined customizations. But don't worry, Frontmacs will generate
+this file for you so that you can see what all configuration variables
+are available.
+
+For everything else, there is all of the files contained in
+`$HOME/.emacs.d/initializers`. Every elisp file contained in this
+directory will be evaluated _after_ Frontmacs has been fully
+configured and initialized, so settings made in these files will
+override anything that comes with Frontmacs out of the box. For
+example, you can create your Ruby configuration with a file called:
+
+`$HOME/.emacs.d/initializers/ruby.el`
+
+``` emacs-lisp
+(eval-after-load 'rspec-mode
+  '(rspec-install-snippets))
+
+(add-to-list 'auto-mode-alist '("Gemfile" . ruby-mode))
+(add-to-list 'auto-mode-alist '("\\.gemspec\\'" . ruby-mode))
+```
+
+Just drop any `.el` file into the `initializers/` directory, and
+Frontmacs will evaluate it.
+
+> Note: When in doubt about whether you should put something in `config.el` or a
+> custom initializer, use an initializer.
+
 ## Development
 
 You will need a patched version of `Cask` to do development on.

--- a/frontmacs-config.el
+++ b/frontmacs-config.el
@@ -1,0 +1,99 @@
+;;; frontmacs-config.el --- Frontmacs: configuration and storage.
+;;;
+;;; Commentary:
+;;;
+;;; This defines configuration variables for how Frontmacs will
+;;; initialize.  The rough outline for booting is as follows:
+;;;
+;;; 1. load .emacs.d/config.el
+;;; 2. load the rest of Frontmacs
+;;; 3. load all of the elisp files in .emacs.d/initializers
+;;;
+;;; .emacs.d/config.el and .emacs.d/initalizers/ will be created for
+;;; you if they don't exist already.
+;;; Code:
+
+(require 'f)
+
+(defvar frontmacs-config-file (f-join user-emacs-directory "config.el")
+  "Frontmacs configuration file.
+
+Frontmacs defines configuration variables that customize how its intializers
+will run.  This file will be loaded by frontmacs before it initializes so that
+any values contained therein can be used by the initialization process
+
+For example, you might want to set the `frontmacs-theme' variable from your
+config in config.el:
+
+  (custom-set-variables '(frontmacs-theme 'zenburn))
+
+Note that these are only the configuration setttings that Frontmacs itself
+exposes, and as a heavily curated system there may not be many.  For
+configuration options that are not Frontmacs specific, use an initializer
+instead")
+
+(defvar frontmacs-initializers-directory (f-join user-emacs-directory "initializers")
+  "All .el files in this directory will be run after Frontmacs initializes.
+
+This is where you would do things like require custom modes and set them up, or
+even write a bunch of custom elisp code.  When in doubt, it's usually safe to
+put stuff in your initializers directory.")
+
+(defvar frontmacs-data-directory (f-join user-emacs-directory "data")
+  "This directory contains persistent application state.
+
+The data directory is for storing things like autosave files and recent lists so
+that they don't get pooped into things like your home directory or your init
+file, but instead go to a well-known location.")
+
+(defgroup frontmacs nil
+  "Frontmacs Configuration"
+  :prefix "frontmacs-"
+  :group 'convenience)
+
+(defcustom frontmacs-theme 'zenburn
+  "Your personal theme."
+  :type 'symbol
+  :group 'frontmacs)
+
+;; by default Emacs poops all customizations set through the
+;; customization UI into your `init.el'. Let's not do that.
+(setq custom-file (f-join frontmacs-data-directory "custom.el"))
+
+;; create your config.el if it isn't created already
+(unless (f-exists?  frontmacs-config-file)
+  (f-write "
+;; Frontmacs configuration
+;;
+(custom-set-variables
+ ;; Change this in order to choose your theme. This will auto install your theme
+ ;; as package with the suffix \"-theme\" appended to the end. So for example,
+ ;; if your theme is set to 'twilight, then it will try and download and require
+ ;; the 'twilight-theme ELPA package.
+ ;;
+ ;; If you want to have your own completely custom theme that isn't available as
+ ;; as an ELPA package, then set this variable to `nil', and roll your own theme
+ ;; in an initializer
+ ;; '(frontmacs-theme 'zenburn)
+ )
+" 'utf-8 frontmacs-config-file))
+
+;; create the initializers directory if it doesn't already exist.
+(unless (f-exists? frontmacs-initializers-directory)
+  (f-mkdir frontmacs-initializers-directory))
+
+;; create the initializers directory if it doesn't already exist.
+(unless (f-exists? frontmacs-data-directory)
+  (f-mkdir frontmacs-data-directory))
+
+;; load confi.el prior to the rest of initialization
+(eval-after-load "frontmacs-config"
+  '(load frontmacs-config-file))
+
+;; load all of the files in the `initializers/' directory after
+;; Frontmacs has fully loaded.
+(eval-after-load "frontmacs"
+  '(mapc 'load (directory-files frontmacs-initializers-directory 't "^[^#.].*el$")))
+
+(provide 'frontmacs-config)
+;;; frontmacs-config.el ends here

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -1,9 +1,11 @@
 ;; -*- eval: (flycheck-mode -1) -*-
 (define-package "frontmacs" "0.1.2" "Frontside config package for emacs"
-  '((magit "2.8.0")
+  '((f "0.19.0")
+    (magit "2.8.0")
     (swiper "0.7.0")
     (projectile "0.13.0")
-    (exec-path-from-shell "1.11"))
+    (exec-path-from-shell "1.11")
+    (page-break-lines "0.11"))
 
   :keywords '("emacs" "awesome" "starterkit")
 

--- a/frontmacs-style.el
+++ b/frontmacs-style.el
@@ -1,0 +1,33 @@
+;;; frontmacs-style.el --- Setup how Emacs looks.
+;;;
+;;; Commentary:
+;;;
+;;; There are three thing that make a good editor good: Capability,
+;;; Performance and Style.  Each of which is critical.  It's the last of
+;;; these, Style, that this module is all about.
+;;;
+;;; Let's make it look good!
+;;;
+;;; Code:
+
+(require 'package)
+
+(when frontmacs-theme
+  ;; `package-install' is finicky about getting passed a symbol. It
+  ;; won't work with the string "zenburn-theme", only the symbol
+  ;; 'zenburn-theme. Same thing with `load-theme'. That's why we have
+  ;; to take `frontmacs-theme' which is a symbol, convert it to a
+  ;; string, concat it with "-theme" and then convert it back to a
+  ;; symbol via `intern'
+  (let ((package-name (intern (concat (symbol-name frontmacs-theme) "-theme"))))
+
+    ;; download the theme package if it is not installed
+    (unless (package-installed-p package-name)
+      (package-refresh-contents)
+      (package-install package-name t))
+
+    ;; load it!
+    (load-theme frontmacs-theme t)))
+
+(provide 'frontmacs-style)
+;;; frontmacs-style.el ends here

--- a/frontmacs.el
+++ b/frontmacs.el
@@ -3,10 +3,13 @@
 ;;; Commentary:
 
 ;;; Code:
+(require 'frontmacs-config)
+(require 'frontmacs-style)
 (require 'frontmacs-system)
 (require 'frontmacs-projectile)
 (require 'frontmacs-completion)
 (require 'frontmacs-vcs)
 (require 'frontmacs-windowing)
+
 (provide 'frontmacs)
 ;;; frontmacs.el ends here

--- a/test/fixtures/boot-sequence/config.el
+++ b/test/fixtures/boot-sequence/config.el
@@ -1,0 +1,5 @@
+;; -*- eval: (flycheck-mode -1) -*-
+(defvar t/boot-sequence (list
+                         :hello "config"
+                         :file frontmacs-config-file
+                         :done (featurep 'frontmacs)))

--- a/test/fixtures/boot-sequence/initializers/hello-initializer.el
+++ b/test/fixtures/boot-sequence/initializers/hello-initializer.el
@@ -1,0 +1,9 @@
+;; -*- eval: (flycheck-mode -1) -*-
+(require 'dash)
+
+(unless (boundp 't/boot-sequence)
+  (error "fixture configuration script did not run"))
+
+(setq t/boot-sequence (-concat t/boot-sequence (list
+                                                :hello "initializer"
+                                                :done (featurep 'frontmacs))))

--- a/test/frontmacs-test.el
+++ b/test/frontmacs-test.el
@@ -1,0 +1,33 @@
+(require 'f)
+
+(ert-deftest it-creates-a-config-and-data-and-initializers-directory()
+  "When you use Frontmacs, it will create a data directory for persistent state
+that is managed by emacs extensions, and also a config directory for you to
+control how it boots up."
+  (t/setup)
+  (shut-up (require 'frontmacs))
+
+  (should (f-exists? (f-join user-emacs-directory "config.el")))
+  (should (f-exists? (f-join user-emacs-directory "initializers")))
+  (should (f-exists? (f-join user-emacs-directory "data"))))
+
+
+(ert-deftest it-runs-config-then-initializer-scripts()
+  "First, frontmacs variables are defined. Then, user config is run. Then
+Frontmacs initializes, then user initializers are run."
+  (t/setup)
+  (f-copy-contents (t/fixture "boot-sequence") t/user-emacs-directory)
+  (shut-up (require 'frontmacs))
+
+  ;; it should have run fixtures/boot-sequence/hello-config.el first
+  ;; then it should have run fixtures/boot-sequence/hello-initializer.el
+  ;; the configuration should be run after `frontside-config' is finished,
+  ;; but the rest of the library has not loaded, where as the initializers are
+  ;; run after the entire `frontmacs' library is loaded
+  (should (boundp 't/boot-sequence))
+  (should (equal (list
+                  :hello "config"
+                  :file frontmacs-config-file
+                  :done nil
+                  :hello "initializer"
+                  :done t) t/boot-sequence)))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,25 @@
+;; -*- eval: (flycheck-mode -1) -*-
+(require 'f)
+(add-to-list 'load-path default-directory)
+
+(defvar t/fixtures-directory (f-join load-file-name "../fixtures"))
+(defvar t/user-emacs-directory (f-join load-file-name "../../build/tests.emacs.d"))
+
+(defun t/setup()
+  "Unload the frontmacs library, then cleanup and setup the sandboxed .emacs.d"
+  (when (featurep 'frontmacs)
+    (unload-feature 'frontmacs t)
+    (unload-feature 'frontmacs-config t))
+
+  (when (f-exists? t/user-emacs-directory)
+    (f-delete t/user-emacs-directory t))
+
+  (f-mkdir t/user-emacs-directory)
+  (setq user-emacs-directory t/user-emacs-directory)
+
+  (custom-set-variables
+   '(frontmacs-theme nil)))
+
+(defun t/fixture(path)
+  "Get the absolute path of tests/fixtures/PATH"
+  (f-join t/fixtures-directory path))


### PR DESCRIPTION
Frontmacs is curated, but it is also needs to be customizable. This allows users to scratch that itch of uniqueness even inside the walled garden of a great out-of-the-box experience. It's also important to have a customization mechanism in place so that we can begin using Frontmacs, but still have a clear way to fill in the gaps that are going to be large at first.

To enable this customization, this is introduces the concept of configuration and initializers. The configuration file (config.el) is for setting variables that will affect the Frontmacs initialization process, and it will be generated for you the first time you install it.

The other capability added is for initializers. Any `.el` file that is dropped into `.emacs.d/initializers` will be evaluated after frontmacs has loaded, and so it can be used as an all-purpose setup mechanism... an escape hatch for anything that Frontmacs hasn't covered yet. In this way, it's just like the normal `init.el` mechanism except it allows you to logically divide up your initializers into separate files according to purpose. E.g.

`.emacs.d/initializers/ruby.el`
`.emacs.d/initializers/javascript.el`
`.emacs.d/initializers/github.el`