### PR TITLE
move projectile state to the data/ directory

### DIFF
--- a/frontmacs-projectile.el
+++ b/frontmacs-projectile.el
@@ -1,7 +1,11 @@
 (require 'f)
 (require 'projectile)
 
+;; Have projectile persist its state into the data/ directory.
 (setq projectile-cache-file (f-join frontmacs-data-directory "projectile.cache"))
+(setq projectile-known-projects-file (f-join frontmacs-data-directory "projectile-bookmarks.eld"))
+
+;; turn on projectile everywhere
 (projectile-global-mode t)
 
 ;; go to project dir when selecting project


### PR DESCRIPTION
`projectile.cache` is already in the `data/` directory. This moves `projectile-bookmarks.eld` there too.