### PR TITLE
save current buffer whenever frame loses focus.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMACS_VERSION=snapshot
+cache:
+  - directories:
+    - $HOME/emacs
 env:
   - EMACS_VERSION=25.1
   - EMACS_VERSION=snapshot

--- a/frontmacs-editing.el
+++ b/frontmacs-editing.el
@@ -123,7 +123,12 @@
 ;; for everything
 (fset 'yes-or-no-p 'y-or-n-p)
 
-;; Autosave when leaving buffer or frame
+;; Autosave when switching buffers, windows, or frames.
+;; Note: Emacs has different concepts of buffers, windows and frames
+;; than you might be used to.
+;;
+;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Buffers-and-Windows.html
+;; https://www.gnu.org/software/emacs/manual/html_node/emacs/Frames.html
 (defadvice switch-to-buffer (before save-buffer-now activate)
   (when buffer-file-name (save-buffer)))
 (defadvice other-window (before other-window-now activate)
@@ -136,6 +141,8 @@
   (when buffer-file-name (save-buffer)))
 (defadvice windmove-right (before other-window-now activate)
   (when buffer-file-name (save-buffer)))
+
+(add-hook 'focus-out-hook (lambda () (when buffer-file-name (save-buffer))))
 
 (provide 'frontmacs-editing)
 


### PR DESCRIPTION
We were handling the cases where you switched to a different window, or to a different buffer within the same window, but we forgot the case when the whole application loses focus.