### PR TITLE
create new frontmacs issues on github from within Emacs.

### DIFF
--- a/frontmacs-devel.el
+++ b/frontmacs-devel.el
@@ -1,0 +1,24 @@
+;;; frontmacs-devel --- Functions related to the development of Frontmacs itself.
+;;
+;;; Commentary:
+;;
+;; Sometimes the development that you're doing is on Frontmacs itself
+;; and so this package contains handy functions for doing just that.
+;;
+;;; Code:
+
+(defvar frontmacs-repository-new-issue-url "https://github.com/thefrontside/frontmacs/issues/new"
+  "The URL at which to file new issues for Frontmacs itself.")
+
+(defun frontmacs/open-issue-on-frontmacs-repo ()
+  "Open up a new issue on the Frontmacs github repository.
+If there is currently selected text, then that text will be used as
+the body of the issue."
+  (interactive)
+  (if (use-region-p)
+      (let ((text (url-encode-url (buffer-substring-no-properties (region-beginning) (region-end)))))
+        (browse-url (concat frontmacs-repository-new-issue-url "?body=" text)))
+    (browse-url frontmacs-repository-new-issue-url)))
+
+(provide 'frontmacs-devel)
+;;; frontmacs-devel.el ends here

--- a/frontmacs.el
+++ b/frontmacs.el
@@ -11,6 +11,7 @@
 (require 'frontmacs-vcs)
 (require 'frontmacs-windowing)
 (require 'frontmacs-editing)
+(require 'frontmacs-devel)
 (require 'frontmacs-keys)
 
 ;; different language modes

--- a/test/frontmacs-devel-test.el
+++ b/test/frontmacs-devel-test.el
@@ -1,0 +1,28 @@
+;; -*- eval: (flycheck-mode -1) -*-
+(require 'frontmacs-devel)
+
+(describe "opening a frontmacs issue from emacs"
+  (before-each
+    (spy-on 'browse-url)
+    (switch-to-buffer "*test-buffer*"))
+
+  (describe "when there is no region selected"
+    (before-each
+      (frontmacs/open-issue-on-frontmacs-repo))
+
+    (it "browses to the repo's new issue tab"
+      (expect 'browse-url :to-have-been-called-with "https://github.com/thefrontside/frontmacs/issues/new")))
+
+  (describe "with a region selected"
+    (before-each
+      (insert "ignore-SOMETHING IS WRONG WITH MY FRONTMACS-ignore")
+      (set-mark 8)
+      (move-to-column 43)
+      ;; for some reason use-region-p won't return true in test :(
+      ;; so we have to stub it to be true.
+      (spy-on 'use-region-p :and-return-value t)
+
+      (frontmacs/open-issue-on-frontmacs-repo))
+
+    (it "browses to the repo's new issue form and pre-fills the selection"
+      (expect 'browse-url :to-have-been-called-with "https://github.com/thefrontside/frontmacs/issues/new?body=SOMETHING%20IS%20WRONG%20WITH%20MY%20FRONTMACS"))))


### PR DESCRIPTION
Add a function `frontmacs/open-issue-on-frontmacs-repo` that will open up an issue on github. If there is text selected, then that text will be used as the body of the issue.

I've also found a great BDD package for elisp called buttercup with which to test features from here on out. I think it's much, much easier than `ERT` https://github.com/jorgenschaefer/emacs-buttercup