### PR TITLE
properly initialize projectile

### DIFF
--- a/frontmacs-projectile.el
+++ b/frontmacs-projectile.el
@@ -1,9 +1,13 @@
 (require 'f)
-(require 'projectile)
 
 ;; Have projectile persist its state into the data/ directory.
 (setq projectile-cache-file (f-join frontmacs-data-directory "projectile.cache"))
 (setq projectile-known-projects-file (f-join frontmacs-data-directory "projectile-bookmarks.eld"))
+
+;; require projectile _after_ the configuration has been set so that it initializes
+;; itself properly
+(require 'projectile)
+
 
 ;; turn on projectile everywhere
 (projectile-global-mode t)


### PR DESCRIPTION
We change the projectile project bookmarks files to be in the frontmacs data/ but projectile reads this file when it is loading, so we move the require to be after the configuration so that it tries to read from the proper place

fixes #58 