### PR TITLE
clone github repos

### DIFF
--- a/frontmacs-keys.el
+++ b/frontmacs-keys.el
@@ -111,6 +111,9 @@
 ;; https://github.com/pidu/git-timemachine
 (global-set-key (kbd "C-x v t") 'git-timemachine)
 
+;; Clone a github repository
+(global-set-key (kbd "C-x v c") #'github-clone)
+
 ;; Counsel provides some nice enhancements to core emacs functions.
 ;; See https://github.com/abo-abo/swiper#counsel for details
 

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -4,6 +4,7 @@
     (magit "2.8.0")
     (git-link "0.4.5")
     (git-timemachine "3.0")
+    (github-clone "0.2")
     (swiper "0.7.0")
     (counsel "0.8.0")
     (flx "0.6.1")


### PR DESCRIPTION
Why go to github to copy the url? Why not just clone github repositories straight from the editor. Adding to the VCS prefix `C-x v` with the `c` pnemonic for "clone" this allows you to do just that.

Type `C-x v c` for great fun.

![2017-04-25 11 56 32](https://cloud.githubusercontent.com/assets/4205/25397610/6d18af8c-29ae-11e7-969d-280935860788.gif)

This will walk you through the github oauth process if you have not done it before. Otherwise, it will just clone the repo.