### PR TITLE
Make flydiff indicator an exclamation point

### DIFF
--- a/frontmacs-editing.el
+++ b/frontmacs-editing.el
@@ -49,7 +49,8 @@
 (require 'undo-tree)
 (global-undo-tree-mode 1)
 
-;; set fringe widths
+;; make the left fringe 2 pixels so the hl-diff indicators aren't so fat
+;; leave the right fringe width at the default 8 pixels
 (fringe-mode '(2 . 8))
 
 ;; setup flycheck to show on the right side of the buffer

--- a/frontmacs-editing.el
+++ b/frontmacs-editing.el
@@ -49,6 +49,9 @@
 (require 'undo-tree)
 (global-undo-tree-mode 1)
 
+;; set fringe widths
+(fringe-mode '(2 . 8))
+
 ;; setup flycheck to show on the right side of the buffer
 (require 'flycheck)
 (setq flycheck-indication-mode 'right-fringe)

--- a/frontmacs-editing.el
+++ b/frontmacs-editing.el
@@ -53,11 +53,11 @@
 (require 'flycheck)
 (setq flycheck-indication-mode 'right-fringe)
 
-;; make the flycheck arrow look like a little triagle.
+;; make the flycheck arrow look like an exclamation point.
 ;; but only do it when emacs runs in a window, not terminal
 (when window-system
   (define-fringe-bitmap 'flycheck-fringe-bitmap-double-arrow
-    [0 0 0 0 0 4 12 28 60 124 252 124 60 28 12 4 0 0 0 0]))
+    [0 24 24 24 24 24 24 0 0 24 24 0 0 0 0 0 0]))
 
 (add-hook 'prog-mode-hook 'flycheck-mode)
 


### PR DESCRIPTION
Default indicator:
<img width="580" alt="flycheck-default" src="https://cloud.githubusercontent.com/assets/5005153/25456652/21802140-2a99-11e7-9b91-46d3680fbcb4.png">

Current indicator:
<img width="580" alt="flycheck-current" src="https://cloud.githubusercontent.com/assets/5005153/25456664/25d16984-2a99-11e7-8e17-a1fd578d08ed.png">

Exclamation point indicator:
<img width="580" alt="flycheck-exclamation" src="https://cloud.githubusercontent.com/assets/5005153/25456669/2972303c-2a99-11e7-9996-21b908eee886.png">

I also decreased the width of the left fringe so the hl-diff indicators aren't so fat.