### PR TITLE
Fix js-doc-insert-function-doc keybinding

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -21,9 +21,9 @@
 ;; setup jsdoc: https://github.com/mooz/js-doc
 ;;
 ;; We use the same prefix for js2r `C-c C-r' because it's an "advanced"
-;; refactory-y type thing.
-(define-key js2-mode-map (kbd "C-c C-r d") #'js-doc-insert-function-doc)
-(define-key js2-mode-map "@" #'js-doc-insert-tag)
+;; refactory-y type thing. The additional `i' prefix is for "insert"
+(define-key js2-refactor-mode-map (kbd "C-c C-r i d") #'js-doc-insert-function-doc)
+(define-key js2-refactor-mode-map "@" #'js-doc-insert-tag)
 
 
 (provide 'frontmacs-javascript)


### PR DESCRIPTION
The previously bound keys were already in use by a prefix command. Decided on `C-c C-r i d` as the keybinding because `C-c C-r i` is already a prefix command in js2-refactor-mode and `C-c C-r i d` can be remembered mnemonically as "insert doc". Also changed the keymap becuase js2-mode-map wasn't working for me and js2-refactor-mode-map makes sense since we're using a refactory prefix.