### PR TITLE
Add bindings for zooming fonts in a frame.

### DIFF
--- a/frontmacs-keys.el
+++ b/frontmacs-keys.el
@@ -140,6 +140,26 @@
 (define-key counsel-find-file-map (kbd "C-j") 'ivy-done)
 (define-key counsel-find-file-map (kbd "RET") 'ivy-alt-done)
 
-(provide 'frontmacs-keys)
 
+;; https://www.emacswiki.org/emacs/zoom-frm.el
+;;
+;; Zoom Frames allows you to change the font-size of the current frame up or down. These are
+;; the suggested bindings from the `zoom-frm' package itself:
+;;
+;;    Emacs 23 and later:
+;;
+(require 'zoom-frm)
+(define-key ctl-x-map [(control ?+)] 'zoom-in/out)
+(define-key ctl-x-map [(control ?-)] 'zoom-in/out)
+(define-key ctl-x-map [(control ?=)] 'zoom-in/out)
+(define-key ctl-x-map [(control ?0)] 'zoom-in/out)
+
+
+;; And then add bindings for the "super" key on OSX so that `⌘ +' will work on a mac.
+(when (eq system-type 'darwin)
+  (global-set-key (kbd "s-+") 'zoom-in/out)
+  (global-set-key (kbd "s--") 'zoom-in/out)
+  (global-set-key (kbd "s-0") 'zoom-in/out))
+
+(provide 'frontmacs-keys)
 ;;; frontmacs-keys.el ends here

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -23,6 +23,7 @@
     (undo-tree "0.6.5")
     (browse-kill-ring "2.0.0")
     (ace-window "0.9.0")
+    (zoom-frm "20170125.1953")
     (expand-region "0.11.0")
     (comment-dwim-2 "1.2.2")
     (company "0.9.2")


### PR DESCRIPTION
Emacs on mac doesn't support the standard ⌘-+ out of the box.

This overrides the default text scaling to work on the frame level (instead of just the buffer) and then Also adds the convenient key bindings back for osx

![2017-07-06 16 11 10](https://user-images.githubusercontent.com/4205/27933256-50030988-6266-11e7-9643-02a0e5c30694.gif)