### PR TITLE
Explicity map in, out, and unzoom functions.

### DIFF
--- a/frontmacs-keys.el
+++ b/frontmacs-keys.el
@@ -157,9 +157,9 @@
 
 ;; And then add bindings for the "super" key on OSX so that `⌘ +' will work on a mac.
 (when (eq system-type 'darwin)
-  (global-set-key (kbd "s-+") 'zoom-in/out)
-  (global-set-key (kbd "s--") 'zoom-in/out)
-  (global-set-key (kbd "s-0") 'zoom-in/out))
+  (global-set-key (kbd "s-+") #'zoom-frm-in)
+  (global-set-key (kbd "s--") #'zoom-frm-out)
+  (global-set-key (kbd "s-0") #'zoom-frm-unzoom))
 
 (provide 'frontmacs-keys)
 ;;; frontmacs-keys.el ends here


### PR DESCRIPTION
While the zoom and unzoom functions seem to work, the "unzoom" function never remembers exactly where it is when using the mac keys. This probably has something to do with the strange `(control ?0)` form which I've never seen before.

In either case, this explicit mapping is every bit as clear, if not clearer, and unzooming to the default zoom level works as expected.

- [ ] TODO: When the zoom/unzoom operations happen, the frame expands or contracts to accomodate the text. Make it so that the frame stays the same size, and only the text expands.