### PR TITLE
Add support for typescript mode.

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -25,5 +25,26 @@
 (define-key js2-refactor-mode-map (kbd "C-c C-r i d") #'js-doc-insert-function-doc)
 (define-key js2-refactor-mode-map "@" #'js-doc-insert-tag)
 
+;; TypeScript:
+;;
+;; setup tide mode, the typescript IDE for Emacs
+;; This is lifted straight from the suggested setup on the TIDE
+;; README https://github.com/ananthakumaran/tide
+(defun fs/setup-tide-mode()
+  (interactive)
+  (tide-setup)
+  (flycheck-mode +1)
+  (setq flycheck-check-syntax-automatically '(save mode-enabled))
+  (eldoc-mode +1)
+  (tide-hl-identifier-mode +1)
+  (company-mode +1))
+
+(add-hook 'typescript-mode-hook #'fs/setup-tide-mode)
+
+;; setup formatting options. The full list can be found at
+;; https://github.com/Microsoft/TypeScript/blob/87e9506/src/services/services.ts#L1244-L1272
+(setq tide-format-options
+      '(:indentSize 2 :tabSize 2))
 
 (provide 'frontmacs-javascript)
+;;; frontmacs-javascript.el ends here

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -38,6 +38,7 @@
     (js2-mode "20170624")
     (js-doc "20160714.2134")
     (rjsx-mode "0.1.3")
+    (tide "2.3.1")
     (emmet-mode "1.0.8")
     (web-mode "14.1")
     (markdown-mode "2.1")


### PR DESCRIPTION
TypeScript is amazing, and TIDE has all the nice refactorings that can be used within TS mode.

I included it in JavaScript setup because it's all JS under the covers, and also because perhaps eventually we'll switch to using TIDE for editing JavaScript code as well.

Currently there are no bindings other than `M-.` for Jump to Symbol, and funcitonality has to be referenced by name.

The following minicast shows using it to find all the references to the `Destroyable` interface, and then renaming it to `Destructastable`.

![2017-07-10 16 47 07](https://user-images.githubusercontent.com/4205/28041979-07f345d0-6591-11e7-80ac-a3e4079896f6.gif)
