### PR TITLE
Add use-package package

### DIFF
--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -48,7 +48,8 @@
     (which-key "2.0.1")
     (volatile-highlights "1.11")
     (multiple-cursors "1.4.0")
-    (drag-stuff "0.3.0")))
+    (drag-stuff "0.3.0")
+    (use-package "2.3")))
 
   :keywords '("emacs" "awesome" "starterkit")
 


### PR DESCRIPTION
Adds `use-package` to allow easier installation of packages in users' custom initializers