### PR TITLE
Use vanilla `rspec` executable to run specs.

### DIFF
--- a/frontmacs-ruby.el
+++ b/frontmacs-ruby.el
@@ -49,4 +49,11 @@
  '(rspec-install-snippets))
 
 
+(custom-set-variables
+
+ ;; don't use Rake to run specs. If your suite doesn't run with just
+ ;; using `bundle exec rspec specs/` then you're doing it wrong.
+ '(rspec-use-rake-when-possible nil))
+
 (provide 'frontmacs-ruby)
+;;; frontmacs-ruby.el ends here


### PR DESCRIPTION
There was a period where everybody seemed to want to run their rspec suite from within their `Rakefile`, but the setup and teardown facilities of rspec itself ought to be sufficient to run your entire suite. Otherwise, what the hell are you doing anyway?

This makes the default to run rspec with rspec, like rspec intended.