### PR TITLE
Make Node.js stacktrace lines clickable

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -46,5 +46,13 @@
 (setq tide-format-options
       '(:indentSize 2 :tabSize 2))
 
+
+;;; parse node.js stack traces in compilation buffer.s
+(require 'compile)
+(add-to-list 'compilation-error-regexp-alist 'node)
+(add-to-list 'compilation-error-regexp-alist-alist
+             '(node "at.*(\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 1 2 3))
+
+
 (provide 'frontmacs-javascript)
 ;;; frontmacs-javascript.el ends here


### PR DESCRIPTION
A really nice thing about emacs is that it recognizes stack traces for just about every language environment. Every language environment except Node.js apparently.

This adds a special node.js compilation-error-regexp that will match node backtraces, so that every line:column in a backtrace is clickable.

![2017-10-13 12 30 40](https://user-images.githubusercontent.com/4205/31558493-ab4b5288-b012-11e7-9324-2965d28e98d3.gif)
