### PR TITLE
Tell cask explicitly where emacs is living.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,11 @@ cache:
   - directories:
     - $HOME/emacs
 env:
-  - EMACS_VERSION=25.1
-  - EMACS_VERSION=snapshot
+  global:
+    - CASK_EMACS=/home/travis/bin/emacs
+  matrix:
+    - EMACS_VERSION=25.1
+    - EMACS_VERSION=snapshot
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin
   - export PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
There's a bug in pyenv that prepends `/usr/bin` to the path, which was futzing up cask's logic for which emacs to use. Previously, there was no `/usr/bin/emacs` so it wasn't a problem. With the latest release of Travis, there is an old version of emacs lying around at `/usr/bin/emacs`  so when pyenv appended `/usr/bin` to PATH it overrode our version of emacs under test living at $HOME/bin

This explicitly sets the CASK_EMACS environment variable so that cask will look there and nowhere else.

See https://github.com/pyenv/pyenv/issues/789 for more details