### PR TITLE
Load .mjs file using our javascript mode.

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -1,9 +1,11 @@
 (require 'js2-mode)
+(require 'rjsx-mode)
 (require 'js2-refactor)
 (require 'js-doc)
 
 ;; use rjsx-mode for all JS files
 (add-to-list 'auto-mode-alist '("\\.js\\'"    . rjsx-mode))
+(add-to-list 'auto-mode-alist '("\\.mjs\\'"    . rjsx-mode))
 (add-to-list 'auto-mode-alist '("\\.pac\\'"   . rjsx-mode))
 (add-to-list 'interpreter-mode-alist '("node" . rjsx-mode))
 

--- a/test/fixtures/javascript.js
+++ b/test/fixtures/javascript.js
@@ -1,0 +1,1 @@
+const message = "This is just a file that has some javascript with  a '.js' extension";

--- a/test/fixtures/javascript.mjs
+++ b/test/fixtures/javascript.mjs
@@ -1,0 +1,1 @@
+const message = "This is just a file that has some javascript with  a '.mjs' extension";

--- a/test/frontmacs-javascript-test.el
+++ b/test/frontmacs-javascript-test.el
@@ -1,0 +1,21 @@
+;; -*- eval: (flycheck-mode -1) -*-
+(require 'frontmacs-javascript)
+(require 'f)
+
+(defvar t/javascript-js (f-join load-file-name "../fixtures/javascript.js"))
+(defvar t/javascript-mjs (f-join load-file-name "../fixtures/javascript.mjs"))
+
+(describe "frontmacs-javascript"
+  (describe "when a .js file is opened"
+    (before-each
+     (find-file t/javascript-js))
+
+    (it "loads rjsx-mode"
+      (expect major-mode :to-be 'rjsx-mode))
+
+  (describe "when a .mjs file is opened"
+    (before-each
+     (find-file t/javascript-mjs))
+
+    (it "loads rjsx-mode"
+      (expect major-mode :to-be 'rjsx-mode)))))


### PR DESCRIPTION
We rarely do it, but sometimes you do encounter `.mjs` files in the
wild. These are file that will be loaded by nodejs, but will not use
the nodule system (commonjs), but will instead use ecmascript modules.

This does two things.

1. Make sure that .mjs files get loaded by rjsx-mode.
2. Institutes a test that ensure it happens.