### PR TITLE
Better line matching in a node stack trace.

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -51,7 +51,7 @@
 (require 'compile)
 (add-to-list 'compilation-error-regexp-alist 'node)
 (add-to-list 'compilation-error-regexp-alist-alist
-             '(node "at.*(\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 1 2 3))
+             '(node "^[[:blank:]]*at \\(.*(\\|\\)\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 2 3 4))
 
 
 (provide 'frontmacs-javascript)


### PR DESCRIPTION
Node has kinda wacky stack traces that can be heterogenous in
formatting. For example:

```
    at /Users/cowboyd/Code/microstates.js/play.mjs:54:14
    at Object.<anonymous> (/Users/cowboyd/Code/microstates.js/play.mjs)
    at Module._compile (module.js:624:30)
```

Notice how the first line has the file:line:colum unwrapped, and the third has it wrapped in `()`. While the second line doesn't have a line number or column!

This improves the error regexp to handle both the first and third line, while still punting on the third.

## Before
![_re-builder__and_comparing_master___cl_improved-node-error-regexp_ _thefrontside_frontmacs](https://user-images.githubusercontent.com/4205/33505617-b463a530-d6b1-11e7-946e-a4f5d6e9665e.png)

## After
![_re-builder_](https://user-images.githubusercontent.com/4205/33505594-965617d0-d6b1-11e7-86b2-e0d28cc12026.png)


## Navigation

![2017-12-01 17 22 32](https://user-images.githubusercontent.com/4205/33507794-5cb9c99e-d6bc-11e7-950f-fd8a05dd778b.gif)
