### PR TITLE
Fix breaking `counsel-projectile` change in `frontmacs-completion`

### DIFF
--- a/frontmacs-completion.el
+++ b/frontmacs-completion.el
@@ -24,7 +24,7 @@
 ;; use Ivy mode for completion
 (ivy-mode 1)
 (setq projectile-completion-system 'ivy)
-(counsel-projectile-on)
+(counsel-projectile-mode)
 
 ;; Make the default completion mechanism a fuzzy search. However, you
 ;; don't really want to use fuzzy matching on lists that have content

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -10,7 +10,7 @@
     (flx "0.6.1")
     (smex "3.0")
     (projectile "0.14.0")
-    (counsel-projectile "20170216.1426")
+    (counsel-projectile "20171227.1315")
     (ag "0.4.7")
     (exec-path-from-shell "1.11")
     (page-break-lines "0.11")


### PR DESCRIPTION
This fixes an error during initialization related to a breaking change in
`counsel-projectile`.

From the `counsel-projectile` Readme:
"The commands counsel-projectile-on, counsel-projectile-off and
counsel-projectile-toggle no longer exist. They are replaced with the
counsel-projectile minor mode. You can toggle this mode either by calling the
counsel-projectile-mode command. or by setting the counsel-projectile-mode
variable throught the Customize interface."

Source: https://github.com/ericdanan/counsel-projectile#upgrading-from-previous-version