### PR TITLE
Clean up the entire buffer if no region is selected.

### DIFF
--- a/frontmacs-editing.el
+++ b/frontmacs-editing.el
@@ -146,6 +146,13 @@
 
 (add-hook 'focus-out-hook (lambda () (when buffer-file-name (save-buffer))))
 
+;; This makes indenting region and untabifying region work on the entire
+;; buffer if no region is selected
+;; https://github.com/bbatsov/crux#using-the-bundled-advices
+(require 'crux)
+(crux-with-region-or-buffer indent-region)
+(crux-with-region-or-buffer untabify)
+
 (provide 'frontmacs-editing)
 
 ;;; frontmacs-editing.el ends here


### PR DESCRIPTION
One of the awesome things about Emacs is that in most coding buffers, `TAB` is not key to insert whitespace but instead to "do the right thing and go to the proper level of indent".

You can do this with a line, or an entire region.

However, if you're wanting to cleanup an entire buffer and have it indent to the right level, then selecting the whole thing and running a cleanup is just busy-work. Ideally we'd like to have a cleanup just default to cleaning up the whole buffer.

By using the `crux-with-region-or-buffer` command advice (middleware), we can do just that. If no region has been selected, then it just uses the entire buffer as the subject of indentation and untabification.

![2018-03-09 11 30 59](https://user-images.githubusercontent.com/4205/37223539-1ab10c14-238e-11e8-8b1b-b0dcfe7b90d2.gif)
