### PR TITLE
Disable scrollbars

### DIFF
--- a/frontmacs-windowing.el
+++ b/frontmacs-windowing.el
@@ -54,4 +54,7 @@ new windows will each be 180 columns wide, and sit just below the threshold.
 (require 'windmove)
 (windmove-default-keybindings 'super)
 
+;; War and scrollbars. what are they good for?
+(scroll-bar-mode -1)
+
 (provide 'frontmacs-windowing)

--- a/frontmacs-windowing.el
+++ b/frontmacs-windowing.el
@@ -55,6 +55,7 @@ new windows will each be 180 columns wide, and sit just below the threshold.
 (windmove-default-keybindings 'super)
 
 ;; War and scrollbars. what are they good for?
+(require 'scroll-bar)
 (scroll-bar-mode -1)
 
 (provide 'frontmacs-windowing)


### PR DESCRIPTION
Using the mouse is rare indeed, and there are better ways to show where you are in the total context of a document. As such, scroll bars just take up space.

Let's disable them.

### Before
<img width="624" alt="_magit-diff__frontmacs_and_comparing_master___cl_disable-scrollbar-mode_ _thefrontside_frontmacs" src="https://user-images.githubusercontent.com/4205/37224086-ae9f0d80-238f-11e8-86b9-8b4eff3ce133.png">

### After
<img width="623" alt="_magit-diff__frontmacs" src="https://user-images.githubusercontent.com/4205/37224186-f5af9672-238f-11e8-8e73-2bf0c70ed25c.png">

