### PR TITLE
Add node_modules/.bin to buffer's exec-path

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -55,6 +55,12 @@
 (add-to-list 'compilation-error-regexp-alist-alist
              '(node "^[[:blank:]]*at \\(.*(\\|\\)\\(.+?\\):\\([[:digit:]]+\\):\\([[:digit:]]+\\)" 2 3 4))
 
+;;; Specific versions of node packages installed on a per-project
+;;; basis are the norm in JS development. So, for example, if you're
+;;; using `eslint' to stylecheck your code, this will make project
+;;; buffers find `node_modules/.bin/eslint' before any other
+;;; executable in their `exec-path'
+(add-hook 'prog-mode-hook #'add-node-modules-path)
 
 (provide 'frontmacs-javascript)
 ;;; frontmacs-javascript.el ends here

--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -60,6 +60,7 @@
 ;;; using `eslint' to stylecheck your code, this will make project
 ;;; buffers find `node_modules/.bin/eslint' before any other
 ;;; executable in their `exec-path'
+(require 'add-node-modules-path)
 (add-hook 'prog-mode-hook #'add-node-modules-path)
 
 (provide 'frontmacs-javascript)

--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -38,6 +38,7 @@
     (js-doc "20160714.2134")
     (rjsx-mode "0.1.3")
     (tide "2.3.1")
+    (add-node-modules-path "1.2.0")
     (emmet-mode "1.0.8")
     (web-mode "14.1")
     (markdown-mode "2.1")


### PR DESCRIPTION
In order to run project-specific executables like `eslint` and/or `stylelint`, it is typical to use either `yarn run` or `npm run` to use the installed version. However, Emacs currently doesn't know to use these executables, and will search for them in the normal path. For example, this means that the eslint style checks won't work unless the `eslint` executable is installed globally which is rarely the case.

Luckily, this is a solved problem. This PR adds a dependency on the `add-node-modules-path` package and uses it to append `node_modules/.bin` to the `exec-path` for any buffer that is in `prog-mode`.

Why `prog-mode` and not `js-mode`? Because there are often non-JavaScript source files in your project that nevertheless use tools written in JavaScript for them to work. An example of this is `stylelint`. It's writteni in JavaScript, but we want it to be on the `exec-path` for CSS files too; not just JavaScript files.

### Before

![image](https://user-images.githubusercontent.com/4205/38828170-6dbca11e-4172-11e8-952f-ee3b65ff6cf4.png)


### After

![image](https://user-images.githubusercontent.com/4205/38828097-2b369b60-4172-11e8-93ab-5be1feff4c6e.png)
