### PR TITLE
Disable js2-mode errors

### DIFF
--- a/frontmacs-javascript.el
+++ b/frontmacs-javascript.el
@@ -20,6 +20,11 @@
 (custom-set-variables '(js-indent-level 2)
                       '(js2-basic-offset 2))
 
+;; disable js2-mode warnings and errors since we'll use eslint
+;; by default.
+(custom-set-variables '(js2-mode-show-parse-errors nil)
+                      '(js2-mode-show-strict-warnings nil))
+
 ;; setup jsdoc: https://github.com/mooz/js-doc
 ;;
 ;; We use the same prefix for js2r `C-c C-r' because it's an "advanced"


### PR DESCRIPTION
By default, js2-mode uses it's own style linter to display warnings
and errors, but these days almost every repo ships with a linting
solution. It's far safer to assume that there will be a lint config
than that the errors we see will be useful.

Let's just disable the parse errors and warnings (note this will not
effect the sytax highlighting)