### PR TITLE
Remove vkill

### DIFF
--- a/frontmacs-pkg.el
+++ b/frontmacs-pkg.el
@@ -17,7 +17,6 @@
     (crux "0.3.0")
     (yasnippet "0.11.0")
     (mocha-snippets "1.0.0")
-    (vkill "20091203.1022")
     (key-chord "20160227.438")
     (hlinum "20160521.2112")
     (undo-tree "0.6.5")

--- a/frontmacs-system.el
+++ b/frontmacs-system.el
@@ -39,10 +39,6 @@
   ;; It's all in the Meta
   (setq ns-function-modifier 'hyper)
 
-  ;; proced-mode doesn't work on OS X so we use vkill instead
-  (autoload 'vkill "vkill" nil t)
-  (global-set-key (kbd "C-x p") 'vkill)
-
   (menu-bar-mode +1)
 
   ;; Enable emoji, and stop the UI from freezing when trying to display them.


### PR DESCRIPTION
## Problem
The `vkill` package seems to have been abandoned, and its absence causes frontmacs config initialization to fail.

## Solution
Remove it. In the future, possibly look for a replacement package.

Fixes https://github.com/thefrontside/frontmacs/issues/126