### PR TITLE
Add `test` target for easily running tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   # off the network and boot up succesfull
   - make init-test
   # run individual tests
-  - cask exec buttercup -L .
+  - make test
   # build the archive for uploading to elpa.frontside.io
   - make archive
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ clean:
 	rm -rf build
 	rm -rf dist
 
+test:
+	cask exec buttercup -L .
+
 # Run Emacs locally with a sandboxed home directory, using the
 # frontmacs config. We point Emacs to the local archive that we built
 # on the system, and also erase it if it was there befor.
@@ -28,3 +31,5 @@ archive: build/packages/archive-contents
 # downloads everything off of the internet
 init-test: build archive
 	FRONTMACS_ARCHIVE=`pwd`/dist/packages/ HOME=`pwd`/build/home emacs -Q --batch --no-init-file --script scripts/init-frontmacs.el
+
+.PHONY: test


### PR DESCRIPTION
Common development tests should be as seamless and simple as possible, but the `cask exec buttercup -L .` command which runs the specs for the project is not the most user friendliest.

This adds the `test` target which is an alias for that command.

> Note: in order to force make to "rebuild" the `test` command every
  time, it needs to be marked as a `.PHONY` target (one that does not
  produce an actual physical artifact)

See
https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html#Phony-Targets