### PR TITLE
Run tests against emacs 26 as the stable version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   global:
     - CASK_EMACS=/home/travis/bin/emacs
   matrix:
-    - EMACS_VERSION=25.1
+    - EMACS_VERSION=26.2
     - EMACS_VERSION=snapshot
 before_install:
   # Configure $PATH: Executables are installed to $HOME/bin


### PR DESCRIPTION
It's been almost 18 months since the release of emacs 26.1, so it's more important to verify that it works on emacs >= 26 than 25 since that constitutes what most folks are using.