### PR TITLE
Disable Caching to support Emacs 26

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,15 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: EMACS_VERSION=snapshot
-cache:
-  - directories:
-    - $HOME/emacs
+
+# There is an issue with caching and Emacs 26
+# So until this is resolved, we need to disable caching in order
+# to reliably install Gnu TLS.
+# https://github.com/flycheck/emacs-travis/issues/22
+#
+# cache:
+#   - directories:
+#     - $HOME/emacs
 env:
   global:
     - CASK_EMACS=/home/travis/bin/emacs
@@ -58,4 +64,4 @@ deploy:
   local_dir: dist/packages
   on:
     branch: master
-    condition: $EMACS_VERSION = 25.1
+    condition: $EMACS_VERSION = 26.2


### PR DESCRIPTION
There is an issue with Emacs 26 and Gnu TLS install where the caching is preventing the proper TLS version from being installed which causes all Emacs 26.x builds to fail.

This temporarily disables caching until such time as it can be resolved. Since the emacs_travis.mk file uses a binary build of emacs where possible, this means that the build only takes a few minutes.

However, a negative consequence is that the snapshot build now takes over 15 minutes on every commit since it is building from source every time.

See https://github.com/flycheck/emacs-travis/issues/22 for details.