### PR TITLE
Use mainline version of Cask.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,7 @@ before_install:
   # Install Emacs (according to $EMACS_VERSION) and Cask
   - make -f emacs-travis.mk install_emacs
 
-  # currently override cask to point to forked version that supports
-  # package manifests. https://github.com/cask/cask/pull/383
-  - echo "Install Cask"
-  - git clone -b specify-package-descriptor --depth=1 https://github.com/cowboyd/cask.git $HOME/.cask
-  - ln -s $HOME/.cask/bin/cask $HOME/bin/cask
-  # - make -f emacs-travis.mk install_cask
+  - make -f emacs-travis.mk install_cask
 
   # Install Texinfo, if you need to build info manuals for your project
   - make -f emacs-travis.mk install_texinfo


### PR DESCRIPTION
For the longest time, we needed to maintain our own version of Cask that supported using a `-pkg.el` file for the package definition. However, with the merging of https://github.com/cask/cask/pull/383 using a fork of Cask is no longer necessary.

This rolls back to the main version of cask that is used by emacs_travis.mk