### PR TITLE
Make it more friendly with use-package

### DIFF
--- a/packages/javascript/frontside-javascript.el
+++ b/packages/javascript/frontside-javascript.el
@@ -197,5 +197,9 @@ to enable refactoring."
   ;; executable in their `exec-path'
   (add-hook 'prog-mode-hook #'add-node-modules-path))
 
+;; Make it so that you only need to say `(use-package frontside-javascript)`
+;;;###autoload
+(setq use-package--frontside-javascript--pre-config-hook #'frontside-javascript)
+
 (provide 'frontside-javascript)
 ;;; frontside-javascript.el ends here


### PR DESCRIPTION
It's redundant to have to declare the use package and then also require it.

```elisp
(use-package frontside-javascript :config (frontside-javascript))
```

Instead, we'd like the fact that you're using `use-package` explicitly to declare your intent to actually use the package. In other words, be able to say:

```elisp
(use-package frontside-javascript)
```

This defines, via autoload, a hook that will be run automatically by `use-package` when frontside-javascript loads. This saves us the typing.

Note that the [`use-package-inject-hooks`][1] variable must be non-nil.

[1]: https://github.com/jwiegley/use-package/blob/master/use-package-core.el#L257-L281