### PR TITLE
Set JavasScript indent to two spaces

### DIFF
--- a/packages/javascript/frontside-javascript-test.el
+++ b/packages/javascript/frontside-javascript-test.el
@@ -17,7 +17,18 @@
   (describe "opening a JS buffer"
     (before-each (find-file "myfile.js"))
     (it "loads rjsx-mode"
-      (expect major-mode :to-be 'rjsx-mode)))
+      (expect major-mode :to-be 'rjsx-mode))
+    (describe "inserting some unformatted text and then formatting it"
+      (before-each
+        (shut-up
+         (insert "{\nfoo: \"bar\"\n}")
+         (activate-mark)
+         (mark-whole-buffer)
+         (indent-for-tab-command)))
+      (it "requires this spec for the next one to pass 🤷" t)
+
+      (it "indents to 2 spaces by default"
+        (expect (buffer-substring 3 8) :to-equal "  foo"))))
 
   (describe "opening a JSX buffer"
     (before-each

--- a/packages/javascript/frontside-javascript.el
+++ b/packages/javascript/frontside-javascript.el
@@ -72,6 +72,9 @@ This is the main entry point which configures JS, JSX, TS, TSX, and NodeJS devel
 (defun frontside-javascript--javascript()
   "Setup for working with JavaScript."
 
+  ;; 2 space tab width
+  (custom-set-default 'js-indent-level 2)
+  (custom-set-default 'js2-basic-offset 2)
 
   ;; Use js2r-refactor-mode which implies using js2-mode.
   ;; see https://github.com/magnars/js2-refactor.el


### PR DESCRIPTION
## Motivation
The convention almost everywhere is to use 2 spaces for indent in JavaScript, however the default in js-mode and js2-mode is 4. All things being equal, we should follow that convention.

## Approach
This sets the default to 2 spaces, but still allows it to be overridden. However, most JavaScript projects, if they do not have this default, set their own defaults