### PR TITLE
unfiddle flycheck settings

### DIFF
--- a/packages/javascript/frontside-javascript.el
+++ b/packages/javascript/frontside-javascript.el
@@ -163,8 +163,6 @@ typescript-mode.el is very barebones, but the expectation around
 
   ;; use flycheck to highlight syntax errors.
   (flycheck-mode +1)
-  (setq flycheck-check-syntax-automatically
-        '(save idle-change new-line mode-enabled))
 
   (cond ((frontside-javascript--deno-project-p)
          (lsp))


### PR DESCRIPTION
## Motivation
The default flycheck settings for how often a buffer is syntax-checked is pretty reasonable these days, and more often than not folks have _more_ permissive flycheck settings. Specifically, I actually recommend `idle-buffer-switch` turned _on_.

## Approach
This change was to add `idle-change` to the list, but since it is already there by default now, just leave it alone.

## Learning

- https://www.flycheck.org/en/latest/user/syntax-checks.html#check-automatically